### PR TITLE
Support setting sourceRpm

### DIFF
--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
@@ -1178,8 +1178,8 @@ final public class RpmPackage
         builder.setPrefixes(this.getPrefixes().toArray(new String[0]));
 
         if (sourceRpm != null) {
-			builder.addHeaderEntry(Header.HeaderTag.SOURCERPM, sourceRpm);
-		}
+		builder.addHeaderEntry(Header.HeaderTag.SOURCERPM, sourceRpm);
+	}
 
         // Process dependencies
         for (RpmPackageAssociation dependency : this.getDependencies()) {

--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
@@ -120,6 +120,11 @@ final public class RpmPackage
      * Packager of RPM
      */
     private String packager = null;
+    
+    /**
+     * Source RPM Name
+     */
+    private String sourceRpm = null;
 
     /**
      * Attach the artifact
@@ -700,6 +705,26 @@ final public class RpmPackage
     {
         return this.packager;
     }
+    
+    /**
+     * Set source RPM name
+     *
+     * @param sourceRpm Package sourceRpm
+     */
+    public void setSourceRpm(String sourceRpm)
+    {
+        this.sourceRpm = sourceRpm;
+    }
+
+    /**
+     * Get source RPM name
+     *
+     * @return sourceRpm
+     */
+    public String getSourceRpm()
+    {
+        return this.sourceRpm;
+    }
 
     /**
      * Set artifact attachment
@@ -1151,6 +1176,10 @@ final public class RpmPackage
         builder.setPackager(this.getPackager());
         builder.setUrl(this.getUrl());
         builder.setPrefixes(this.getPrefixes().toArray(new String[0]));
+
+        if (sourceRpm != null) {
+			builder.addHeaderEntry(Header.HeaderTag.SOURCERPM, sourceRpm);
+		}
 
         // Process dependencies
         for (RpmPackageAssociation dependency : this.getDependencies()) {


### PR DESCRIPTION
Make it possible to set the sourceRpm header.  

This actually is meant to be a workaround for a bug in createrepo that incorrectly overrides the architecture of an RPM if it doesn't specify a sourcerpm.
http://createrepo.baseurl.org/gitweb?p=createrepo.git;a=commitdiff;h=20a4999107bd0493dbd3994d23a60b43a601b1dd

Discussion of the problem: https://communities.vmware.com/thread/285894?start=0&tstart=0
