### PR TITLE
Add support for creating symlinks

### DIFF
--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/BaseOwnedObject.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/BaseOwnedObject.java
@@ -1,0 +1,125 @@
+
+/*
+    Copyright 2017 Teradata
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package uk.co.codezen.maven.redlinerpm.rpm;
+
+public abstract class BaseOwnedObject
+{
+    /**
+     * Destination file mode
+     */
+    private int fileMode = 0;
+
+    /**
+     * Destination file owner
+     */
+    private String owner = null;
+
+    /**
+     * Destination file group
+     */
+    private String group = null;
+
+    protected abstract RpmPackage getPackage();
+
+    /**
+     * Set file mode
+     *
+     * @param fileMode File mode
+     */
+    public void setFileMode(int fileMode)
+    {
+        this.fileMode = fileMode;
+    }
+
+    /**
+     * Get file mode, or the default setting if not set
+     *
+     * @return File mode
+     */
+    public int getModeOrDefault()
+    {
+        if (0 == this.fileMode) {
+            System.err.println(this.getPackage());
+            System.err.println(this.getPackage().getMojo());
+            System.err.println(this.getPackage().getMojo().getDefaultFileMode());
+            return this.getPackage().getMojo().getDefaultFileMode();
+        }
+        else {
+            return this.fileMode;
+        }
+    }
+
+    /**
+     * Set file owner
+     *
+     * @param owner File owner
+     */
+    public void setOwner(String owner)
+    {
+        if (null != owner && owner.equals("")) {
+            owner = null;
+        }
+
+        this.owner = owner;
+    }
+
+    /**
+     * Get file owner, or the default setting if not set
+     *
+     * @return File owner
+     */
+    public String getOwnerOrDefault()
+    {
+        if (null == this.owner)
+        {
+            return this.getPackage().getMojo().getDefaultOwner();
+        }
+        else {
+            return this.owner;
+        }
+    }
+
+    /**
+     * Set file group
+     *
+     * @param group File group
+     */
+    public void setGroup(String group)
+    {
+        if (null != group && group.equals("")) {
+            group = null;
+        }
+
+        this.group = group;
+    }
+
+    /**
+     * Get file group, or the default setting if not set
+     *
+     * @return File group
+     */
+    public String getGroupOrDefault()
+    {
+        if (null == this.group) {
+            return this.getPackage().getMojo().getDefaultGroup();
+        }
+        else {
+            return this.group;
+        }
+    }
+}

--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmLink.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmLink.java
@@ -1,0 +1,90 @@
+
+/*
+    Copyright 2017 Teradata
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package uk.co.codezen.maven.redlinerpm.rpm;
+
+public class RpmLink extends BaseOwnedObject
+{
+    /**
+     * RPM package
+     */
+    private RpmPackage rpmPackage = null;
+
+    private String path;
+    private String target;
+
+    /**
+     * Set associated RPM package
+     *
+     * @param rpmPackage RPM package
+     */
+    public void setPackage(RpmPackage rpmPackage)
+    {
+        this.rpmPackage = rpmPackage;
+    }
+
+    /**
+     * Get associated RPM package
+     *
+     * @return RPM package
+     */
+    @Override
+    public RpmPackage getPackage()
+    {
+        return this.rpmPackage;
+    }
+
+    /**
+     * Set symlink path
+     *
+     * @param path symlink path
+     */
+    public void setPath(String path)
+    {
+        this.path = path;
+    }
+
+    /**
+     * Get symlink path
+     *
+     * @return symlink path
+     */
+    public String getPath()
+    {
+        return path;
+    }
+
+    /**
+     * Set symlink target
+     *
+     * @param target symlink target
+     */
+    public void setTarget(String target)
+    {
+        this.target = target;
+    }
+
+    /**
+     * Get symlink target
+     *
+     * @return symlink target
+     */
+    public String getTarget()
+    {
+        return target;
+    }
+}

--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackage.java
@@ -237,6 +237,11 @@ final public class RpmPackage
     private List<RpmPackageAssociation> conflicts = new ArrayList<RpmPackageAssociation>();
 
     /**
+     * Links
+     */
+    private List<RpmLink> links = new ArrayList<RpmLink>();
+
+    /**
      * Package file matching rules
      */
     private List<RpmPackageRule> rules = new ArrayList<RpmPackageRule>();
@@ -455,6 +460,32 @@ final public class RpmPackage
     public List<RpmPackageAssociation> getConflicts()
     {
         return this.conflicts;
+    }
+
+    /**
+     * Set package links
+     *
+     * @param links Package links
+     */
+    public void setLinks(List<RpmLink> links)
+    {
+        if (null != links) {
+            for (RpmLink link : links) {
+                link.setPackage(this);
+            }
+        }
+
+        this.links = links;
+    }
+
+    /**
+     * Get package links
+     *
+     * @return Package links
+     */
+    public List<RpmLink> getLinks()
+    {
+        return this.links;
     }
 
     /**
@@ -1241,6 +1272,15 @@ final public class RpmPackage
             }
         }
 
+        // Process Links
+        for (RpmLink link : this.getLinks()) {
+            builder.addLink(
+                    link.getPath(),
+                    link.getTarget(),
+                    link.getModeOrDefault(),
+                    link.getOwnerOrDefault(),
+                    link.getGroupOrDefault());
+        }
 
         // Event scripting
         this.getLog().debug("Setting event hook scripts");

--- a/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackageRule.java
+++ b/src/main/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackageRule.java
@@ -37,7 +37,7 @@ import java.util.*;
  * RPM file
  * Represents an file to be included within the RPM
  */
-final public class RpmPackageRule
+final public class RpmPackageRule extends BaseOwnedObject
 {
     /**
      * RPM package
@@ -55,21 +55,6 @@ final public class RpmPackageRule
     private String destination = null;
 
     /**
-     * Destination file mode
-     */
-    private int fileMode = 0;
-
-    /**
-     * Destination file owner
-     */
-    private String owner = null;
-
-    /**
-     * Destination file group
-     */
-    private String group = null;
-
-    /**
      * List of file include rules
      */
     private List<String> includes = new ArrayList<String>();
@@ -83,7 +68,6 @@ final public class RpmPackageRule
      * File directives
      */
     private Directive directive = new Directive();
-
 
     /**
      * Set associated RPM package
@@ -100,6 +84,7 @@ final public class RpmPackageRule
      *
      * @return RPM package
      */
+    @Override
     public RpmPackage getPackage()
     {
         return this.rpmPackage;
@@ -165,90 +150,6 @@ final public class RpmPackageRule
         }
         else {
             return this.destination;
-        }
-    }
-
-    /**
-     * Set file mode
-     *
-     * @param fileMode File mode
-     */
-    public void setFileMode(int fileMode)
-    {
-        this.fileMode = fileMode;
-    }
-
-    /**
-     * Get file mode, or the default setting if not set
-     *
-     * @return File mode
-     */
-    public int getModeOrDefault()
-    {
-        if (0 == this.fileMode) {
-            return this.getPackage().getMojo().getDefaultFileMode();
-        }
-        else {
-            return this.fileMode;
-        }
-    }
-
-    /**
-     * Set file owner
-     *
-     * @param owner File owner
-     */
-    public void setOwner(String owner)
-    {
-        if (null != owner && owner.equals("")) {
-            owner = null;
-        }
-
-        this.owner = owner;
-    }
-
-    /**
-     * Get file owner, or the default setting if not set
-     *
-     * @return File owner
-     */
-    public String getOwnerOrDefault()
-    {
-        if (null == this.owner)
-        {
-            return this.getPackage().getMojo().getDefaultOwner();
-        }
-        else {
-            return this.owner;
-        }
-    }
-
-    /**
-     * Set file group
-     *
-     * @param group File group
-     */
-    public void setGroup(String group)
-    {
-        if (null != group && group.equals("")) {
-            group = null;
-        }
-
-        this.group = group;
-    }
-
-    /**
-     * Get file group, or the default setting if not set
-     *
-     * @return File group
-     */
-    public String getGroupOrDefault()
-    {
-        if (null == this.group) {
-            return this.getPackage().getMojo().getDefaultGroup();
-        }
-        else {
-            return this.group;
         }
     }
 

--- a/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/BasedOwnedObjectTest.java
+++ b/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/BasedOwnedObjectTest.java
@@ -1,0 +1,70 @@
+
+/*
+    Copyright 2017 Teradata
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package uk.co.codezen.maven.redlinerpm.rpm;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class BasedOwnedObjectTest
+{
+    protected abstract BaseOwnedObject getBaseOwnedObject();
+
+    @Test
+    public void modeAccessors()
+    {
+        assertEquals(0644, this.getBaseOwnedObject().getModeOrDefault());
+        this.getBaseOwnedObject().setFileMode(0755);
+        assertEquals(0755, this.getBaseOwnedObject().getModeOrDefault());
+    }
+
+    @Test
+    public void ownerAccessors()
+    {
+        this.getBaseOwnedObject().setOwner("");
+        assertEquals("root", this.getBaseOwnedObject().getOwnerOrDefault());
+
+        this.getBaseOwnedObject().setOwner(null);
+        assertEquals("root", this.getBaseOwnedObject().getOwnerOrDefault());
+
+        assertEquals("root", this.getBaseOwnedObject().getOwnerOrDefault());
+        this.getBaseOwnedObject().setOwner("owner");
+        assertEquals("owner", this.getBaseOwnedObject().getOwnerOrDefault());
+
+        this.getBaseOwnedObject().setOwner("");
+        assertEquals("root", this.getBaseOwnedObject().getOwnerOrDefault());
+    }
+
+    @Test
+    public void groupAccessors()
+    {
+        this.getBaseOwnedObject().setGroup("");
+        assertEquals("root", this.getBaseOwnedObject().getGroupOrDefault());
+
+        this.getBaseOwnedObject().setGroup(null);
+        assertEquals("root", this.getBaseOwnedObject().getGroupOrDefault());
+
+        assertEquals("root", this.getBaseOwnedObject().getGroupOrDefault());
+        this.getBaseOwnedObject().setGroup("group");
+        assertEquals("group", this.getBaseOwnedObject().getGroupOrDefault());
+
+        this.getBaseOwnedObject().setGroup("");
+        assertEquals("root", this.getBaseOwnedObject().getGroupOrDefault());
+    }
+
+}

--- a/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/RpmLinkTest.java
+++ b/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/RpmLinkTest.java
@@ -1,0 +1,74 @@
+
+/*
+    Copyright 2017 Teradata
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package uk.co.codezen.maven.redlinerpm.rpm;
+
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Before;
+import uk.co.codezen.maven.redlinerpm.mojo.PackageRpmMojo;
+
+import java.io.File;
+
+public class RpmLinkTest extends BasedOwnedObjectTest
+{
+    String testOutputPath;
+
+    private Log log;
+
+    private RpmLink  rpmLink;
+    private RpmPackage rpmPackage;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        // Test output path
+        this.testOutputPath = System.getProperty("project.build.testOutputDirectory");
+
+        // Create mojo
+        PackageRpmMojo mojo = new PackageRpmMojo();
+        mojo.setDefaultFileMode(0644);
+        mojo.setDefaultOwner("root");
+        mojo.setDefaultGroup("root");
+        mojo.setDefaultDestination(String.format("%svar%swww%stest", File.separator, File.separator, File.separator));
+        mojo.setBuildPath(testOutputPath);
+
+        // Empty maven project is required
+        MavenProject mavenProject = new MavenProject();
+        mojo.setProject(mavenProject);
+
+        // Mojo logger
+        this.log = new DefaultLog(new ConsoleLogger());
+        mojo.setLog(this.log);
+
+        // RPM package
+        this.rpmPackage = new RpmPackage();
+        this.rpmPackage.setMojo(mojo);
+
+        // RPM package rule
+        this.rpmLink = new RpmLink();
+        this.rpmLink.setPackage(rpmPackage);
+    }
+
+    @Override
+    public BaseOwnedObject getBaseOwnedObject()
+    {
+        return rpmLink;
+    }
+}

--- a/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackageRuleTest.java
+++ b/src/test/java/uk/co/codezen/maven/redlinerpm/rpm/RpmPackageRuleTest.java
@@ -40,7 +40,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RpmPackageRuleTest
+public class RpmPackageRuleTest extends BasedOwnedObjectTest
 {
     String testOutputPath;
 
@@ -79,6 +79,12 @@ public class RpmPackageRuleTest
         this.rpmFileRule = new RpmPackageRule();
         this.rpmFileRule.setPackage(rpmPackage);
         this.rpmFileRule.setBase("build");
+    }
+
+    @Override
+    public BaseOwnedObject getBaseOwnedObject()
+    {
+        return rpmFileRule;
     }
 
     @Test
@@ -125,48 +131,6 @@ public class RpmPackageRuleTest
         this.rpmFileRule.setDestination(String.format("%sfoo", File.separator));
         assertEquals(String.format("%sfoo", File.separator), this.rpmFileRule.getDestination());
         assertEquals(String.format("%sfoo", File.separator), this.rpmFileRule.getDestinationOrDefault());
-    }
-
-    @Test
-    public void modeAccessors()
-    {
-        assertEquals(0644, this.rpmFileRule.getModeOrDefault());
-        this.rpmFileRule.setFileMode(0755);
-        assertEquals(0755, this.rpmFileRule.getModeOrDefault());
-    }
-
-    @Test
-    public void ownerAccessors()
-    {
-        this.rpmFileRule.setOwner("");
-        assertEquals("root", this.rpmFileRule.getOwnerOrDefault());
-
-        this.rpmFileRule.setOwner(null);
-        assertEquals("root", this.rpmFileRule.getOwnerOrDefault());
-
-        assertEquals("root", this.rpmFileRule.getOwnerOrDefault());
-        this.rpmFileRule.setOwner("owner");
-        assertEquals("owner", this.rpmFileRule.getOwnerOrDefault());
-
-        this.rpmFileRule.setOwner("");
-        assertEquals("root", this.rpmFileRule.getOwnerOrDefault());
-    }
-
-    @Test
-    public void groupAccessors()
-    {
-        this.rpmFileRule.setGroup("");
-        assertEquals("root", this.rpmFileRule.getGroupOrDefault());
-
-        this.rpmFileRule.setGroup(null);
-        assertEquals("root", this.rpmFileRule.getGroupOrDefault());
-
-        assertEquals("root", this.rpmFileRule.getGroupOrDefault());
-        this.rpmFileRule.setGroup("group");
-        assertEquals("group", this.rpmFileRule.getGroupOrDefault());
-
-        this.rpmFileRule.setGroup("");
-        assertEquals("root", this.rpmFileRule.getGroupOrDefault());
     }
 
     @Test


### PR DESCRIPTION
Redline has support for adding symlinks to RPMs. This exposes that support via the maven plugin.

Example of usage:
```
    <links>
        <link>
            <path>/usr/lib/presto/etc</path>
            <target>/etc/presto</target>
        </link>
    </links>
```